### PR TITLE
Follow-up: fix load parsing regressions for bouquet/auction persistence

### DIFF
--- a/Journal.java
+++ b/Journal.java
@@ -350,7 +350,7 @@ public class Journal {
 					} else if (line.startsWith("BouquetName=")) {
 						auctionBouquetName = line.substring(11);
 					} else if (line.startsWith("BouquetDayCreated=")) {
-						auctionBouquetDayCreated = Integer.parseInt(line.substring(17));
+						auctionBouquetDayCreated = Integer.parseInt(line.substring(18));
 					} else if (line.startsWith("BouquetFlower=")) {
 						String[] flowerData = line.substring(13).split(",");
 						if (flowerData.length >= 6) {
@@ -374,11 +374,25 @@ public class Journal {
 						recognitionBonusApplied = Boolean.parseBoolean(line.substring(23));
 					}
 				} else if (section.equals("KNOWN_BOUQUETS") && line.startsWith("Composition=")) {
-					String[] parts = line.substring(12).split(",", 3);
-					if (parts.length >= 2) {
-						knownBouquetCompositions.put(parts[0], parts[1]);
-						if (parts.length == 3 && !parts[2].isEmpty()) {
-							bouquetHighScores.put(parts[0], Integer.parseInt(parts[2]));
+					String compositionData = line.substring(12);
+					Integer parsedHighScore = null;
+
+					int lastComma = compositionData.lastIndexOf(',');
+					if (lastComma > 0) {
+						String maybeScore = compositionData.substring(lastComma + 1);
+						if (!maybeScore.isEmpty() && maybeScore.matches("-?\\d+")) {
+							parsedHighScore = Integer.parseInt(maybeScore);
+							compositionData = compositionData.substring(0, lastComma);
+						}
+					}
+
+					int separatorIndex = compositionData.lastIndexOf(',');
+					if (separatorIndex > 0) {
+						String signature = compositionData.substring(0, separatorIndex);
+						String knownName = compositionData.substring(separatorIndex + 1);
+						knownBouquetCompositions.put(signature, knownName);
+						if (parsedHighScore != null) {
+							bouquetHighScores.put(signature, parsedHighScore);
 						}
 					}
 				} else if (section.equals("GARDEN_PLOTS")) {


### PR DESCRIPTION
### Motivation
- Save files with active auctions or known bouquet recipes could fail to load because `Journal.loadGame` used an incorrect substring offset and a naive comma split that broke comma-containing bouquet signatures.
- Those parsing bugs caused `Integer.parseInt` and similar exceptions that prevented restoration of auction and known-bouquet state.

### Description
- Fix `BouquetDayCreated` parsing in `Journal.loadGame` by changing `line.substring(17)` to `line.substring(18)` so the numeric day is parsed without the leading `=`.
- Rework `Composition=` parsing in `Journal.loadGame` to preserve comma-joined bouquet signatures by extracting an optional trailing numeric high score and splitting on the last remaining comma to separate `signature` and `knownName`, then storing values in `knownBouquetCompositions` and `bouquetHighScores` when present.

### Testing
- Ran `javac *.java`, which completed successfully and verified the codebase compiles after the changes.
- Attempted an automated persistence smoke test for active-auction and known-bouquet save/load, but end-to-end runtime validation was blocked by missing runtime data (`flowers.csv`) in the environment so full verification could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998ce7c1f3c83218803b9db73b62b81)