### PR TITLE
Fix bouquet naming edge cases and clarify plant withering causes

### DIFF
--- a/BouquetActions.java
+++ b/BouquetActions.java
@@ -69,9 +69,13 @@ public class BouquetActions {
         } else {
             // Ask if they want to name this new composition
             System.out.print("\nWould you like to give this bouquet a custom name? (yes/no): ");
-            String nameChoice = scanner.nextLine().toLowerCase();
+            String nameChoice = scanner.nextLine().trim().toLowerCase();
             
-            if (nameChoice.equals("yes")) {
+            // Only explicit "no" or "n" skips naming; anything else proceeds to naming prompt.
+            if (!nameChoice.equals("no") && !nameChoice.equals("n")) {
+                if (!nameChoice.equals("yes") && !nameChoice.equals("y")) {
+                    System.out.println("Interpreting response as yes. Enter a name to continue.");
+                }
                 System.out.print("Enter bouquet name: ");
                 customName = scanner.nextLine().trim();
                 if (customName.isEmpty()) {

--- a/Journal.java
+++ b/Journal.java
@@ -348,7 +348,7 @@ public class Journal {
 					} else if (line.startsWith("CurrentBid=")) {
 						currentBid = Double.parseDouble(line.substring(11));
 					} else if (line.startsWith("BouquetName=")) {
-						auctionBouquetName = line.substring(11);
+						auctionBouquetName = line.substring(12);
 					} else if (line.startsWith("BouquetDayCreated=")) {
 						auctionBouquetDayCreated = Integer.parseInt(line.substring(18));
 					} else if (line.startsWith("BouquetFlower=")) {

--- a/Player1.java
+++ b/Player1.java
@@ -443,6 +443,13 @@ public class Player1 {
 					totalMutated++;
 				} else if (stageAfter.equals("Withered")) {
 					totalWithered++;
+					String witherReason = plot.getLastWitherReason();
+					String plotType = plot.isFlowerPot() ? "flower pot" : "plot #" + (i + 1);
+					String plantName = plot.getPlantedFlower() != null ? plot.getPlantedFlower().getName() : "A plant";
+					if (witherReason == null || witherReason.isEmpty()) {
+						witherReason = "an unknown reason";
+					}
+					addJournalEntry("🥀 " + plantName + " withered in " + plotType + " because " + witherReason + ".");
 				} else {
 					totalGrew++;
 				}

--- a/gardenPlot.java
+++ b/gardenPlot.java
@@ -26,6 +26,7 @@ public class gardenPlot {
     
     // NEW: Track consecutive days without water for escalating penalties
     private int consecutiveDaysWithoutWater;
+    private String lastWitherReason;
     
     /**
      * Creates a new garden plot with default values
@@ -38,6 +39,7 @@ public class gardenPlot {
         this.soilQuality = "Average";
         this.isFlowerPot = false;
         this.consecutiveDaysWithoutWater = 0;
+        this.lastWitherReason = null;
     }
     
     /**
@@ -69,6 +71,14 @@ public class gardenPlot {
         this.consecutiveDaysWithoutWater = days;
     }
     
+    /**
+     * Returns the reason the current/most recent plant withered during advanceDay.
+     * Reset when a new plant is planted or harvested.
+     */
+    public String getLastWitherReason() {
+        return lastWitherReason;
+    }
+
     public boolean isFlowerPot() {
         return isFlowerPot;
     }
@@ -145,6 +155,7 @@ public class gardenPlot {
         flower.setDaysPlanted(1);
         this.plantedFlower = flower;
         this.consecutiveDaysWithoutWater = 0; // Reset counter for new plant
+        this.lastWitherReason = null;
         return true;
     }
     
@@ -161,6 +172,7 @@ public class gardenPlot {
         this.plantedFlower = null;
         this.isWatered = false;
         this.consecutiveDaysWithoutWater = 0; // Reset counter
+        this.lastWitherReason = null;
         return harvestedFlower;
     }
     
@@ -264,6 +276,9 @@ public class gardenPlot {
             return false;
         }
         
+        // Clear previous wither reason for this day
+        lastWitherReason = null;
+
         // Increment days planted
         plantedFlower.setDaysPlanted(plantedFlower.getDaysPlanted() + 1);
         
@@ -282,6 +297,7 @@ public class gardenPlot {
             // Day 7 without water: Instant wither
             if (consecutiveDaysWithoutWater >= 7) {
                 plantedFlower.setDurability(0); // Triggers auto-wither in Flower.java
+                lastWitherReason = "it went 7 consecutive days without water";
                 // Plant is now withered, reset counter
                 consecutiveDaysWithoutWater = 0;
             } else {
@@ -331,6 +347,10 @@ public class gardenPlot {
             if (this.isFertilized && Math.random() < 0.0075) {
                 upgradeSoilQuality();
             }
+            if (lastWitherReason == null) {
+                lastWitherReason = "its durability reached 0 from neglect";
+            }
+            plantedFlower.setDurability(0);
             return true; // State changed (withered)
         }
         
@@ -401,6 +421,8 @@ public class gardenPlot {
                     
                     if (Math.random() < witherProbability) {
                         plantedFlower.setGrowthStage("Withered");
+                        plantedFlower.setDurability(0);
+                        lastWitherReason = "it naturally withered at mature stage (soil quality affects this chance)";
                         didGrow = true;
                     }
                     // If doesn't wither, stays Matured for another day


### PR DESCRIPTION
### Motivation

- Prevent stray characters from appearing in restored auction bouquet names by fixing parsing during load.
- Make bouquet naming robust so players who type a name when prompted don't accidentally skip naming unless they explicitly say `no`/`n`.
- Make plant withering transparent by recording why a plant withered and ensuring durability is set to `0` whenever a wither occurs.

### Description

- Corrected auction bouquet name parsing in `Journal.java` by adjusting the substring offset used when reading `BouquetName=` so names no longer gain a leading `=` character.
- Updated bouquet naming flow in `BouquetActions.java` so the input is trimmed and lowercased, and only `"no"` or `"n"` skip naming while other responses (including direct names) proceed to the name prompt.
- Added `lastWitherReason` to `gardenPlot.java` and set explicit reasons when a plant withers from seven days without water or when it probabilistically withers at the mature stage, and forced durability to `0` on these wither paths.
- Surface wither reasons in the journal by reading `plot.getLastWitherReason()` in `Player1.java` and adding a descriptive journal entry stating which plant in which plot withered and why.

### Testing

- Compiled the project with `javac *.java` and the compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b61810b9883218434d7694ef73964)